### PR TITLE
Adding double_as_longlong and longlong_as_double 

### DIFF
--- a/include/hip/hipcl_mathlib.hh
+++ b/include/hip/hipcl_mathlib.hh
@@ -1472,3 +1472,18 @@ EXPORT int __any(int predicate);
 EXPORT uint64_t __ballot(int predicate);
 
 #endif
+
+#if defined(__HIP_DEVICE_COMPILE__)
+
+extern "C" {
+NON_OVLD int64_t GEN_NAME(double_as_longlong)(double x);
+NON_OVLD double GEN_NAME(longlong_as_double)(int64_t x);
+}
+EXPORT int64_t __double_as_longlong(double x) { return GEN_NAME(double_as_longlong)(x); }
+EXPORT double __longlong_as_double(int64_t x) { return GEN_NAME(longlong_as_double)(x); }
+
+#else
+EXPORT int64_t __double_as_longlong(double x);
+EXPORT double __longlong_as_double(int64_t x);
+#endif
+

--- a/lib/bitcode/mathlib.cl
+++ b/lib/bitcode/mathlib.cl
@@ -762,3 +762,11 @@ EXPORT float CL_NAME2(shfl_down, f)(float var, uint delta) {
 int CL_NAME(group_all)(int pred) { return sub_group_all(pred); }
 int CL_NAME(group_any)(int pred) { return sub_group_any(pred); }
 ulong CL_NAME(group_ballot)(int pred) { return sub_group_reduce_add(pred ? (ulong)1 << get_sub_group_local_id() : 0); }
+
+
+long CL_NAME(double_as_longlong)(double x) {
+  return __builtin_astype(x, long);
+}
+double CL_NAME(longlong_as_double)(long x) {
+  return __builtin_astype(x, double);
+}

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -82,7 +82,8 @@ endfunction()
 
 
 set(SAMPLES
-    hipmath
+     hiplonglong
+     hipmath
     hiptest
     bit_extract
     hcc_dialects

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -82,8 +82,8 @@ endfunction()
 
 
 set(SAMPLES
-     hiplonglong
-     hipmath
+    hiplonglong
+    hipmath
     hiptest
     bit_extract
     hcc_dialects

--- a/samples/hiplonglong/CMakeLists.txt
+++ b/samples/hiplonglong/CMakeLists.txt
@@ -1,0 +1,3 @@
+# hiplonglong
+
+add_hipcl_test(hiplonglong hiplonglong PASSED main.cpp)

--- a/samples/hiplonglong/main.cpp
+++ b/samples/hiplonglong/main.cpp
@@ -1,0 +1,61 @@
+#include <hip/hip_runtime.h>
+#include <assert.h>
+#include <stdio.h>
+
+#define CHECK(cmd)							\
+    do {                                                                                              \
+      hipError_t error = cmd;						\
+        if (error != hipSuccess) {                                                                 \
+            fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error,         \
+                    __FILE__, __LINE__);                                                           \
+            exit(1);                                                                    \
+        }                                                                                          \
+    } while(0)
+
+
+__global__ void convert_to_long_long(double * double_val, long long *long_long_val) {
+
+  *long_long_val = __double_as_longlong( *double_val );
+
+}  
+__global__ void convert_to_double(long long * long_long_val, double *double_val) {
+
+  *double_val = __longlong_as_double( *long_long_val );
+
+}  
+
+int main(){
+
+  double h_double = 1.0;
+  long long h_long_long;
+
+  double *d_double = NULL;
+  long long *d_long_long = NULL;
+
+  CHECK(hipMalloc(&d_double, sizeof(double)));
+  CHECK(hipMalloc(&d_long_long, sizeof(long long)));
+
+  CHECK(hipMemcpy(d_double, &h_double, sizeof(double), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(d_long_long, &h_long_long, sizeof(long long), hipMemcpyHostToDevice));
+
+  hipLaunchKernelGGL(convert_to_long_long, 1, 1, 0, 0, d_double, d_long_long);
+
+  CHECK(hipMemcpy(&h_long_long, d_long_long, sizeof(double), hipMemcpyDeviceToHost));
+
+  assert( h_long_long == 0x3FF0000000000000 );
+  assert( h_long_long == *((long long *) &h_double) );
+
+
+  hipLaunchKernelGGL(convert_to_double, 1, 1, 0, 0, d_long_long, d_double);
+
+  CHECK(hipMemcpy(&h_double, d_double, sizeof(double), hipMemcpyDeviceToHost));
+
+  assert( h_double == 1.0 );
+  assert( h_double == *((double *) &h_long_long) );
+
+  
+  CHECK(hipFree(d_double));
+  CHECK(hipFree(d_long_long));
+  printf("PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
This commit adds in implementations for double_as_longlong and longlong_as_double. It includes a test for these functions as well.